### PR TITLE
Bump `simplecov`

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -35,12 +35,13 @@ jobs:
       - name: spec
         env:
           CI_RUBY_VERSION: ${{ matrix.ruby }}
+          CC_TEST_REPORTER_ID: dummy # Value doesn't matter, enables json formatter
         run: COVERAGE=true bundle exec rake spec
       - name: Upload Coverage Artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-ubuntu-${{ matrix.ruby }}
-          path: coverage/.resultset.json
+          path: coverage/coverage.json
           if-no-files-found: error
 
   spec-jruby:
@@ -97,7 +98,7 @@ jobs:
         if: ${{ env.CC_TEST_REPORTER_ID != '' }}
         with:
           coverageLocations: |
-            ${{github.workspace}}/coverage-*/.resultset.json:simplecov
+            ${{github.workspace}}/coverage-*/coverage.json:simplecov
 
   ascii_spec:
     name: Ascii Spec - ${{ matrix.os }} ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,7 @@ gem 'rspec', '~> 3.7'
 gem 'rubocop-performance', '~> 1.21.0'
 gem 'rubocop-rake', '~> 0.6.0'
 gem 'rubocop-rspec', '~> 3.0.0'
-# Workaround for cc-test-reporter with SimpleCov 0.18.
-# Stop upgrading SimpleCov until the following issue will be resolved.
-# https://github.com/codeclimate/test-reporter/issues/418
-gem 'simplecov', '~> 0.10', '< 0.18'
+gem 'simplecov', '~> 0.20'
 gem 'stackprof', platform: :mri
 gem 'test-queue'
 gem 'yard', '~> 0.9'


### PR DESCRIPTION
Recent simplecov versions have issues with the codeclimate reporter This can be sidestepped by manually specifying the json formatter

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
